### PR TITLE
Implement Lookahead Youla LTI Controller

### DIFF
--- a/src/ros2_car_control/config/car_control.yaml
+++ b/src/ros2_car_control/config/car_control.yaml
@@ -19,9 +19,9 @@ car_control:
 
     pp_lookahead: 1.0         # pure pursuit lookahead dist [m]
 
-    Youla_GcA: [1.0733 -0.4128 0.2741 0.0; 0.5 0.0 0.0 0.0; 0.0 0.5 0.0 0.0; 0.0 0.0 0.5 0.0]
-    Youla_GcB: [2; 0.0; 0.0; 0.0]
-    Youla_GcC: [0.5195 -0.6425 -0.6239 0.0001]
+    Youla_GcA: [1.8934 -1.0907 0.4767 -0.2260; 1.0 0.0 0.0 0.0; 0.0 0.5 0.0 0.0; 0.0 0.0 0.5 0.0]
+    Youla_GcB: [8; 0.0; 0.0; 0.0]
+    Youla_GcC: [0.5445 -1.2909 2.0142 -1.0329]
     Youla_GcD: [0.0]
 
     hinf_matrices: "Hinf_Controller.json"   # json title of Hinf Matrices

--- a/src/ros2_car_control/config/car_control.yaml
+++ b/src/ros2_car_control/config/car_control.yaml
@@ -19,9 +19,9 @@ car_control:
 
     pp_lookahead: 1.0         # pure pursuit lookahead dist [m]
 
-    Youla_GcA: [2.5231 -1.0908 0.6855 -0.1142; 2.0 0 0 0; 0 0.5 0 0; 0 0 0.25 0]
-    Youla_GcB: [0.5; 0.0; 0.0; 0.0]
-    Youla_GcC: [0.2534 -0.1027 -0.0473 0.0124]
+    Youla_GcA: [1.0733 -0.4128 0.2741 0.0; 0.5 0.0 0.0 0.0; 0.0 0.5 0.0 0.0; 0.0 0.0 0.5 0.0]
+    Youla_GcB: [2; 0.0; 0.0; 0.0]
+    Youla_GcC: [0.5195 -0.6425 -0.6239 0.0001]
     Youla_GcD: [0.0]
 
     hinf_matrices: "Hinf_Controller.json"   # json title of Hinf Matrices

--- a/src/ros2_car_control/config/car_control.yaml
+++ b/src/ros2_car_control/config/car_control.yaml
@@ -19,7 +19,7 @@ car_control:
 
     pp_lookahead: 1.0         # pure pursuit lookahead dist [m]
 
-    Youla_Gca: [2.5231 -1.0908 0.6855 -0.1142; 2.0 0 0 0; 0 0.5 0 0; 0 0 0.25 0]
+    Youla_GcA: [2.5231 -1.0908 0.6855 -0.1142; 2.0 0 0 0; 0 0.5 0 0; 0 0 0.25 0]
     Youla_GcB: [0.5; 0.0; 0.0; 0.0]
     Youla_GcC: [0.2534 -0.1027 -0.0473 0.0124]
     Youla_GcD: [0.0]

--- a/src/ros2_car_control/config/car_control.yaml
+++ b/src/ros2_car_control/config/car_control.yaml
@@ -19,9 +19,9 @@ car_control:
 
     pp_lookahead: 1.0         # pure pursuit lookahead dist [m]
 
-    Youla_Gca: [1.0 0.0 0.0 0.0; 0.0 1.0 0.0 0.0; 0.0 0.0 1.0 0.0; 0.0 0.0 0.0 1.0]
-    Youla_GcB: [1.0; 0.0; 0.0; 0.0]
-    Youla_GcC: [1.0 0.0 0.0 0.0]
+    Youla_Gca: [2.5231 -1.0908 0.6855 -0.1142; 2.0 0 0 0; 0 0.5 0 0; 0 0 0.25 0]
+    Youla_GcB: [0.5; 0.0; 0.0; 0.0]
+    Youla_GcC: [0.2534 -0.1027 -0.0473 0.0124]
     Youla_GcD: [0.0]
 
     hinf_matrices: "Hinf_Controller.json"   # json title of Hinf Matrices

--- a/src/ros2_car_control/ros2_car_control/youlaController.py
+++ b/src/ros2_car_control/ros2_car_control/youlaController.py
@@ -21,20 +21,35 @@ class YoulaController():
         distance_to_waypoint = []
         # waypoints = []
 
-        for i in range(len(self.waypoints.x)):
-            distance_to_waypoint.append((pose_x - self.waypoints.x[i])**2 + (pose_y - self.waypoints.y[i])**2)
-            # waypoints.append([self.waypoints.x[i],self.waypoints.y[i],self.waypoints.psi[i])
-            nearest_waypoint_index = distance_to_waypoint.index(min(distance_to_waypoint))
-        # nearest_waypoint_index = np.argmin(distance_to_waypoint)
-        # ref_x, ref_y, ref_yaw = waypoints[nearest_waypoint_index]
-        
+        # There are two ways we can implement the output feedback here: 
+        #   1. we find the reference waypoint closest to some point ahead of
+        #   the vehicle (lookahead) and compute crosstrack error.
+        #   2. we find the reference waypoint closest to the vehicle c.g. and
+        #   compute crosstrack error and yaw error. Then the total error is
+        #   crosstrack_error + lookahead*yaw_error.
+
         # lookahead = 0
         # front_axle_x = pose_x + lookahead * np.cos(pose_psi)
         # front_axle_y = pose_y + lookahead * np.sin(pose_psi)
 
+        for i in range(len(self.waypoints.x)):
+            # Uncomment below 3 lines for option 1.
+            # distance_to_waypoint.append(
+            #     (front_axle_x - self.waypoints.x[i])**2 \
+            #         + (front_axle_y - self.waypoints.y[i])**2)
+
+            distance_to_waypoint.append((pose_x - self.waypoints.x[i])**2 + (pose_y - self.waypoints.y[i])**2)
+            # waypoints.append([self.waypoints.x[i],self.waypoints.y[i],self.waypoints.psi[i])
+            nearest_waypoint_index = distance_to_waypoint.index(min(distance_to_waypoint))
+        # nearest_waypoint_index = np.argmin(distance_to_waypoint)
+        # ref_x, ref_y, ref_psi = waypoints[nearest_waypoint_index]
+
         # ref_to_axle = np.array([front_axle_x - ref_x, front_axle_y - ref_y])
-        # crosstrack_vector = np.array([np.sin(ref_yaw), -np.cos(ref_yaw)])
-        # lateral_error = ref_to_axle.dot(crosstrack_vector)
+        # crosstrack_vector = np.array([np.sin(ref_psi), -np.cos(ref_psi)])
+        # lateral_error = -ref_to_axle.dot(crosstrack_vector)
+
+        # Uncomment below for option 2.
+        # lateral_error += pose_psi - ref_psi
 
         # This lateral error calculation might not work out if there is a
         # lookahead distance. Consider the example where there is zero

--- a/src/ros2_car_control/ros2_car_control/youlaController.py
+++ b/src/ros2_car_control/ros2_car_control/youlaController.py
@@ -14,12 +14,33 @@ class YoulaController():
         self.waypoints = waypoints
 
     def get_commands(self,pose_x,pose_y,pose_psi,v):
+        # Not sure if ROS 2 fixes this problem, but you might have to store the
+        # waypoints locally so that the callback doesn't overwrite them.
+        # waypoints = self.waypoints
+
         distance_to_waypoint = []
+        # waypoints = []
 
         for i in range(len(self.waypoints.x)):
             distance_to_waypoint.append((pose_x - self.waypoints.x[i])**2 + (pose_y - self.waypoints.y[i])**2)
+            # waypoints.append([self.waypoints.x[i],self.waypoints.y[i],self.waypoints.psi[i])
             nearest_waypoint_index = distance_to_waypoint.index(min(distance_to_waypoint))
+        # nearest_waypoint_index = np.argmin(distance_to_waypoint)
+        # ref_x, ref_y, ref_yaw = waypoints[nearest_waypoint_index]
+        
+        # lookahead = 0
+        # front_axle_x = pose_x + lookahead * np.cos(pose_psi)
+        # front_axle_y = pose_y + lookahead * np.sin(pose_psi)
 
+        # ref_to_axle = np.array([front_axle_x - ref_x, front_axle_y - ref_y])
+        # crosstrack_vector = np.array([np.sin(ref_yaw), -np.cos(ref_yaw)])
+        # lateral_error = ref_to_axle.dot(crosstrack_vector)
+
+        # This lateral error calculation might not work out if there is a
+        # lookahead distance. Consider the example where there is zero
+        # crosstrack error with a lookahead distance of 1 m. I think this calc
+        # will produce a lateral error of 1 or -1 m. The above calculation is
+        # what I used for the DOT project. Maybe it'll work.
         lateral_error_size = np.sqrt(distance_to_waypoint[nearest_waypoint_index])
         psi_vector = [np.cos(pose_psi),np.sin(pose_psi)]
         error_vector = [self.waypoints.x[nearest_waypoint_index] - pose_x, self.waypoints.y[nearest_waypoint_index]-pose_y]
@@ -27,6 +48,14 @@ class YoulaController():
 
         lateral_error = lateral_error_size  * lateral_error_sign
 
+        # new_Gc_states = self.GcA.dot(self.Gc_states) \
+        #    + self.GcB.dot(lateral_error)
+        # steering_angle = self.GcC.dot(self.Gc_states) \
+        #    + self.GcD.dot(lateral_error)
+
+        # Not sure if you'll have a dimension issue here. If you do try the
+        # code snippet above. Alternatively you replace "*" with "@" in 
+        # python 3.
         new_Gc_states = self.GcA * self.Gc_states + self.GcB * lateral_error
         steering_angle = self.GcC * self.Gc_states + self.GcD * lateral_error
 


### PR DESCRIPTION
The major changes are:
1. The inclusion of the discrete state space equations with a sampling time of 20 Hz = 0.05s. 
2. There are suggested changes to `youlaController.py` that are commented out. 

The designed controller was done in MATLAB 2021b with the following:
- scale vehicle parameters: 
```    
'm', 5.568,...
    'l_f', .205,...
    'l_r', .199,...
    'C_alpha_f', 6.932,...
    'C_alpha_r', 6.918,...
    'I_z', 0.167
```
- lookahead distance of 0.5 m
- Longitudinal velocity of 1 m/s
- `T = k*(tau_1*s + 1) / (s^2 + 2*zeta_1*omega_n1*s + omega_n1^2) / ...
    (s^2 + 2*zeta_2*omega_n2*s + omega_n2^2);`
- `[Gc, T, S, Y, L] = youlaDesign(Gp(1),'T', T, params, [k, tau_1]);`
- Controller parameters:
```
params.omega_n1 = 1.9;
params.zeta_1 = 0.707;
params.omega_n2 = 35;
params.zeta_2 = 0.707;
```
- The bandwidth is 4.09 rad/s
- The DiskMargin is 1.0734.
- In a step response for T(s) the overshoot is ~20% and settling time ~3 s
- The controller discretization frequency is 20 Hz = 0.05 s.
- In a step response for Y(s) the peak is ~4.5 and settles to +/- 0.5 at ~0.5 s.

- Controller bode for continuous and discrete.
![image](https://user-images.githubusercontent.com/61514829/226133926-fc1c65b4-9b2e-4d55-87f7-03adf263348f.png)

- T,S,L bode plot:
![image](https://user-images.githubusercontent.com/61514829/226133967-dc976aa7-2e31-4c8f-9fa1-adf115ac44c8.png)

- Gp, Gc, Y, L bode plot:
![image](https://user-images.githubusercontent.com/61514829/226133994-5bdef4f7-5850-4896-a964-7c5fc7d8f644.png)

- PZ Map of T:
![image](https://user-images.githubusercontent.com/61514829/226134005-609dfc9f-59c0-44a2-a07d-12071ba7d275.png)
